### PR TITLE
Correct use of ffi.util.template requires numbered indexes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -57,7 +57,7 @@ function ComicMeta:processFile(cbz_file)
     local comicInfo, ok = ComicLib.ComicInfo:new(cbz_file)
     if not ok or comicInfo == nil then
         UIManager:show(InfoMessage:new({
-            text = T(_("Failed to open CBZ file: {file}"), { file = cbz_file }),
+            text = T(_("Failed to open CBZ file: %1"), cbz_file),
         }))
 
         return


### PR DESCRIPTION
```lua
--[[--
The util.template function allows for better translations through
dynamic positioning of place markers. The range of place markers
runs from %1 to %99, but normally no more than two or three should
be required. There are no provisions for escaping place markers.

@usage
    output = util.template(
        _("Hello %1, welcome to %2."),
        name,
        company
    )

This function was inspired by Qt:
<http://qt-project.org/doc/qt-4.8/internationalization.html#use-qstring-arg-for-dynamic-text>
--]]
function util.template(str, ...)
    local params = table.pack(...)
    -- shortcut:
    if params.n == 0 then return str end
    local result = string.gsub(str, "%%([1-9][0-9]?)",
        function(i)
            return params[tonumber(i)]
        end)
    return result
end
```