### PR TITLE
fix: convert series_index to number when applicable

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -74,7 +74,7 @@ function ComicMeta:processFile(comic_file)
         title = comicInfo.metadata.Title,
         authors = comicInfo.metadata.Writer,
         series = comicInfo.metadata.Series,
-        series_index = comicInfo.metadata.Number,
+        series_index = tonumber(comicInfo.metadata.Number),
         description = comicInfo.metadata.Summary,
         keywords = comicInfo.metadata.Tags,
         language = comicInfo.metadata.LanguageISO,
@@ -95,6 +95,8 @@ function ComicMeta:processFile(comic_file)
             end
 
             metadata[key] = out
+        elseif key == "series_index" then
+            metadata[key] = value
         else
             metadata[key] = util.htmlEntitiesToUtf8(value)
         end

--- a/main.lua
+++ b/main.lua
@@ -74,7 +74,7 @@ function ComicMeta:processFile(comic_file)
         title = comicInfo.metadata.Title,
         authors = comicInfo.metadata.Writer,
         series = comicInfo.metadata.Series,
-        series_index = tonumber(comicInfo.metadata.Number),
+        series_index = tonumber(comicInfo.metadata.Number) or comicInfo.metadata.Number,
         description = comicInfo.metadata.Summary,
         keywords = comicInfo.metadata.Tags,
         language = comicInfo.metadata.LanguageISO,


### PR DESCRIPTION
Ensure series_index is always a numeric value by converting the metadata.Number field using tonumber(). This prevents type mismatches when the series index is expected to be a number by downstream components.

- Convert series_index to numeric type in metadata mapping

Change-Id: 66cc22e8f7ce6acf5dca35b2d959e2d7
Change-Id-Short: ttnnxxlrksnl
Fixes: #42