### PR TITLE
Resolve lib directories relative to plugin main dir

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -4,9 +4,12 @@ Plugin for KOReader to extract metadata from comic (.cbz and .cbr) files as Cust
 @module koplugin.ComicMeta
 --]]
 --
-package.path = package.path .. ";plugins/comicmeta.koplugin/lib/comiclib/?.lua"
-package.path = package.path .. ";plugins/comicmeta.koplugin/lib/comiclib/lib/?.lua"
-package.path = package.path .. ";plugins/comicmeta.koplugin/lib/comiclib/third_party/?/?.lua"
+
+local plugindir = debug.getinfo(1, "S").source:match("@?(.*/)") or "./"
+
+package.path = package.path .. ";" .. plugindir .. "lib/comiclib/?.lua"
+package.path = package.path .. ";" .. plugindir .. "lib/comiclib/lib/?.lua"
+package.path = package.path .. ";" .. plugindir .. "lib/comiclib/third_party/?/?.lua"
 
 local ComicLib = require("comiclib")
 local Dispatcher = require("dispatcher") -- luacheck:ignore


### PR DESCRIPTION
On android, the previous code resulted in relative paths, which did not work. With this code, the path is absolute, which should work everywhere

Fixes #46