### PR TITLE
fix for self-closing tags

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -87,6 +87,9 @@ function ComicMeta:processFile(comic_file)
 
     -- Fixup metadata
     for key, value in pairs(metadata) do
+        if type(value) ~= "string" then
+            value = ""
+        end
         if key == "keywords" then
             local out = ""
             local values = util.splitToArray(value, ",", false)

--- a/main.lua
+++ b/main.lua
@@ -87,7 +87,7 @@ function ComicMeta:processFile(comic_file)
 
     -- Fixup metadata
     for key, value in pairs(metadata) do
-        if type(value) ~= "string" then
+        if type(value) == "table" then
             value = ""
         end
         if key == "keywords" then


### PR DESCRIPTION
Self-closing tags like f.e. <Writer/> parses like an empty table instead of empty string so the extraction fails. So this fix makes them empty value instead.